### PR TITLE
feat: add set_CMV_11 function and basic test cases

### DIFF
--- a/set_CMV.py
+++ b/set_CMV.py
@@ -1,7 +1,7 @@
 def set_CMV():
     """
         A list of the 15 Launch Interceptor Conditions (LIC)
-		
+        
 
         Parameters
         ----------
@@ -19,72 +19,71 @@ def set_CMV():
     pass
 
 def set_CMV_0():
-	pass
+    pass
 
 def set_CMV_1():
-	pass
+    pass
 
 def set_CMV_2():
-	pass
+    pass
 
 def set_CMV_3():
-	pass
+    pass
 
 def set_CMV_4():
-	pass
+    pass
 
 def set_CMV_5():
-	pass
+    pass
 
 def set_CMV_6():
-	pass
+    pass
 
 def set_CMV_7():
-	pass
+    pass
 
 def set_CMV_8():
-	pass
+    pass
 
 def set_CMV_9():
-	pass
+    pass
 
 def set_CMV_10():
-	pass
+    pass
 
-def set_CMV_11(G_PTS, NUMPOINTS, x, y):
-	"""
+def set_CMV_11(num_points, datapoints, parameters):
+    """
         Set CMV_11 based on LIC 11
-		
-		Parameters
+        
+        Parameters
         ----------
-        G_PTS : (int)
-            Number of consecutive points between the two datapoints x[i] and x[j].
-		NUMPOINTS : (int)
-			Number of datapoints. Equal to the length of the data vectors x and y
-        x       : (list of ints/floats)
-            List of x coordinates in the trajectory plane
-		y       : (list of ints/floats)
-            List of y coordinates in the trajectory plane
+       num_points : (int)
+            Total number of data points
+        datapoints : List[Tuple[float, float]]
+            List of tuples 
+        parameters : (Dict)
+            Contains all the LIC and CMV parameters 
 
         Returns Bool depending on if LIC 11 is fulfilled
-	"""
-	if NUMPOINTS < 3:
-		return False
-	assert (isinstance(G_PTS, int)), "G_PTS needs to be an int"
-	assert (isinstance(NUMPOINTS, int)), "NUMPOINTS needs to be an int"
-	assert (1<= G_PTS and G_PTS <= NUMPOINTS-2), "CMV_11: G_PTS value not between 1 and NUMPOINTS-2"
-	assert (len(x) == NUMPOINTS), "length of x vector should be equal to number of data points (NUMPOINTS)"
-	
-	for i in range(NUMPOINTS-G_PTS-1):
-		if x[i+G_PTS+1]-x[i] < 0:
-			return True
-	return False
+
+    """
+    gpts = parameters["gpts"]
+
+    if num_points < 3:
+        return False
+    
+    assert (1<= gpts and gpts <= num_points-2), "CMV_11: G_PTS value not between 1 and NUMPOINTS-2"
+
+    for i in range(num_points-gpts-1):
+        if datapoints[i+gpts+1][0]-datapoints[i][0] < 0:
+            return True
+    return False
 
 def set_CMV_12():
-	pass
+    pass
 
 def set_CMV_13():
-	pass
+    pass
 
 def set_CMV_14():
-	pass
+    pass

--- a/test_decide.py
+++ b/test_decide.py
@@ -7,34 +7,22 @@ class TestDecide(unittest.TestCase):
 
     def test_cmv_11(self):
         # Define test parameters (should probably be moved to JSON test file later)
-        G_PTS = 4
-        NUMPOINTS = 10
-        NUMPOINTS_less = 1
-        y   = [0,0,0,0,0,0,0,0,0,0]
-        x_1 = [0,1,2,3,4,5,6,7,8,9]
-        x_2 = [0,3,5,6,1,2,8,9,10,0]
-        x_3 = [-1,-2,-3,0,1,2,0,0,0,0]
-        
+        parameters = {
+            "gpts" : 4
+        }
 
-        x_short = [0]
+        num_points = 10
+        num_points_less = 1
+
+        datapoints_1 = [(0,0),(1,0),(2,0),(3,0),(4,0),(5,0),(6,0),(7,0),(8,0),(9,0)]
+        datapoints_2 = [(0,0),(3,0),(5,0),(6,0),(1,0),(2,0),(8,0),(9,0),(10,0),(0,0)]
+        datapoints_3 = [(-1,0),(-2,0),(-3,0),(0,0),(1,0),(2,0),(0,0),(0,0),(0,0),(0,0)]
 
         # Test computational logic in set_CMV_11 function
-        self.assertFalse(set_CMV_11(G_PTS,NUMPOINTS,x_1,y), "test_cmv_11: x vector is only increasing")
-        self.assertTrue(set_CMV_11(G_PTS,NUMPOINTS,x_2,y), "test_cmv_11: x vector includes correct set of datapoints")
-        self.assertTrue(set_CMV_11(G_PTS,NUMPOINTS,x_3,y), "test_cmv_11: x vector includes correct set of datapoints")
-        self.assertFalse(set_CMV_11(G_PTS,NUMPOINTS_less,x_2,y), "test_cmv_11: NUMPOINTS less than 3")
-
-        # Test built-in assertions in set_CMV_0 function
-        with self.assertRaises(AssertionError):   # Tests that length of x vector equal to NUMPOINTS int
-            set_CMV_11(G_PTS,NUMPOINTS,x_short,y)
-        G_PTS_str = "4"
-        with self.assertRaises(AssertionError):   # Tests that G_PTS variable is an int
-            set_CMV_11(G_PTS_str,NUMPOINTS,x_short,y)
-        NUMPOINTS_str = "10"
-        with self.assertRaises(TypeError):        # Tests that NUMPOINTS variable is an int
-            set_CMV_11(G_PTS,NUMPOINTS_str,x_short,y)
-        with self.assertRaises(AssertionError):   # Tests that G_PTS is between 1 and NUMPOINTS-2
-            set_CMV_11(G_PTS,NUMPOINTS,x_short,y)
+        self.assertFalse(set_CMV_11(num_points, datapoints_1, parameters), "test_cmv_11: x vector is only increasing")
+        self.assertTrue(set_CMV_11( num_points, datapoints_2, parameters), "test_cmv_11: x vector includes correct set of datapoints")
+        self.assertTrue(set_CMV_11( num_points, datapoints_3, parameters), "test_cmv_11: x vector includes correct set of datapoints")
+        self.assertFalse(set_CMV_11(num_points_less, datapoints_2, parameters), "test_cmv_11: NUMPOINTS less than 3")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Motivation:
The set_CMV_11 function addresses and computes the LIC (Launch Interceptor Conditions) 11. Basic test cases handle incorrect input to the function along with evaluating correct computational performance

Resolves: #25

Authored by: Ludvig Skare lskare@kth.se