### PR TITLE
doc: add autogenerated docstring documentation

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -1,0 +1,9 @@
+assignment-1
+============
+
+.. toctree::
+   :maxdepth: 4
+
+   decide
+   set_CMV
+   test_decide

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,33 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+import sys
+import os
+# The code of the modules can be found at the root of the repository
+sys.path.insert(0, os.path.abspath('../..'))
+
+project = 'assignment-1'
+copyright = '2024, Dante Astorga Castillo, Rasmus Danielsson, Sebastian Montén, Ludvig Skare, Victor Stenmark'
+author = 'Dante Astorga Castillo, Rasmus Danielsson, Sebastian Montén, Ludvig Skare, Victor Stenmark'
+release = '1.0'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = ['sphinx.ext.autodoc']
+
+templates_path = ['_templates']
+exclude_patterns = []
+
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'alabaster'
+html_static_path = ['_static']

--- a/docs/source/decide.rst
+++ b/docs/source/decide.rst
@@ -1,0 +1,7 @@
+decide module
+=============
+
+.. automodule:: decide
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,22 @@
+.. assignment-1 documentation master file, created by
+   sphinx-quickstart on Mon Jan 29 18:16:54 2024.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to assignment-1's documentation!
+========================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+   
+   decide
+   set_CMV
+   ../test_decide 
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/source/set_CMV.rst
+++ b/docs/source/set_CMV.rst
@@ -1,0 +1,7 @@
+set\_CMV module
+===============
+
+.. automodule:: set_CMV
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/test_decide.rst
+++ b/docs/source/test_decide.rst
@@ -1,0 +1,7 @@
+test\_decide module
+===================
+
+.. automodule:: test_decide
+   :members:
+   :undoc-members:
+   :show-inheritance:


### PR DESCRIPTION
Motivation: writing documentation manually is a tedious task. With sphinx, documentation is generated from docstrings.

Resolves #29