### PR TITLE
fix: fix remaining unit tests

### DIFF
--- a/LIC_evaluation.py
+++ b/LIC_evaluation.py
@@ -190,8 +190,8 @@ def evaluate_LIC_6(num_points, data_points, parameters):
     N_PTS = parameters['npts']
     DIST = parameters['dist']
 
-    assert (3 <= N_PTS and N_PTS <= num_points), "CMV_11: `N_PTS` value is not between 3 and `num_points`."
-    assert (0 <= DIST), "CMV_11: `DIST` value is not greater than or equal to 0."
+    assert (3 <= N_PTS and N_PTS <= num_points), "CMV_6: `N_PTS` value is not between 3 and `num_points`."
+    assert (0 <= DIST), "CMV_6: `DIST` value is not greater than or equal to 0."
 
     # The cases `N_PTS < 3` and `N_PTS > num_points` are still being handled, for robustness.
     if num_points < 3 or N_PTS < 3 or N_PTS > num_points:

--- a/test_decide.py
+++ b/test_decide.py
@@ -3,7 +3,7 @@ import unittest
 from LIC_evaluation import *
 
 class TestDecide(unittest.TestCase):
-    def test_cmv_4_two_valid_sets(self):
+    def test_lic_4_two_valid_sets(self):
         parameters = {
             'qpts' : 4,
             'quads' : 3
@@ -12,7 +12,7 @@ class TestDecide(unittest.TestCase):
         num_points = len(data_points)
         self.assertTrue(evaluate_LIC_4(num_points, data_points, parameters), "4 consecutive points occupy 4 quadrants")
 
-    def test_cmv_4_no_valid_sets(self):
+    def test_lic_4_no_valid_sets(self):
         parameters = {
             'qpts' : 4,
             'quads' : 3
@@ -21,7 +21,7 @@ class TestDecide(unittest.TestCase):
         num_points = len(data_points)
         self.assertFalse(evaluate_LIC_4(num_points, data_points, parameters), "No 4 consecutive points occupy 4 quadrants")
 
-    def test_cmv_4_impossible(self):
+    def test_lic_4_impossible(self):
         parameters = {
             'qpts' : 2,
             'quads' : 3
@@ -30,7 +30,7 @@ class TestDecide(unittest.TestCase):
         num_points = len(data_points)
         self.assertFalse(evaluate_LIC_4(num_points, data_points, parameters), "Impossible since quads > qpts")
 
-    def test_cmv_4_last_set_in_datapoints_is_valid(self):
+    def test_lic_4_last_set_in_datapoints_is_valid(self):
         parameters = {
             'qpts' : 3,
             'quads' : 2
@@ -39,7 +39,7 @@ class TestDecide(unittest.TestCase):
         num_points = len(data_points)
         self.assertTrue(evaluate_LIC_4(num_points, data_points, parameters), "The qpts last points occupy more than 2 quadrants")
 
-    def test_cmv_4_qpts_equal_to_numpoints_and_condition_still_met(self):
+    def test_lic_4_qpts_equal_to_numpoints_and_condition_still_met(self):
         data_points = [(0.1, 0.1), (0.1, -0.1), (0.1, -0.1), (0.1, -0.1), (-0.1, 0.1), (-0.1, -0.1)]
         num_points = len(data_points)
         parameters = {
@@ -48,7 +48,7 @@ class TestDecide(unittest.TestCase):
         }
         self.assertTrue(evaluate_LIC_4(num_points, data_points, parameters), "qpts = num_points, all 4 quadrants are occupied")
 
-    def test_cmv_0(self):
+    def test_lic_0(self):
         # Define test parameters (should probably be moved to JSON test file later)
         parameters = {}
         parameters["length1"] = 2
@@ -64,7 +64,7 @@ class TestDecide(unittest.TestCase):
         self.assertTrue(evaluate_LIC_0(num_points, datapoints_2, parameters), "CMV_0: Maximum distance is larger than parameter LENGTH1")
         self.assertTrue(evaluate_LIC_0(num_points, datapoints_3, parameters), "CMV_0: Maximum distance is larger than parameter LENGTH1")
 
-    def test_cmv_3(self): 
+    def test_lic_3(self): 
         ''' Tests the function evaluate_LIC_3 which calculates the 
             LIC3 condition. This function passes two false instances
             (where there exists no triangle in any consecutive data points 
@@ -76,7 +76,7 @@ class TestDecide(unittest.TestCase):
         
         # TRUE case
         parameters_true1 = { 
-            "AREA1" : 7 
+            "area1" : 7 
         } 
 
         data_points_true1 = [ 
@@ -86,7 +86,7 @@ class TestDecide(unittest.TestCase):
         ]
         # TRUE case
         parameters_true2 = { 
-            "AREA1" : 40 
+            "area1" : 40 
         } 
 
         data_points_true2 = [ 
@@ -94,9 +94,9 @@ class TestDecide(unittest.TestCase):
             (-1.0,1.0), (0.0,1.0), (1.0,1.0), 
             (-1.0,-1.0), (0.0,-1.0), (1.0,-1.0) 
         ]
-        # FALSE case
+        # false case
         parameters_false1 = { 
-            "AREA1" : 7 
+            "area1" : 7 
         } 
 
         data_points_false1 = [ 
@@ -104,9 +104,9 @@ class TestDecide(unittest.TestCase):
             (-1.0,0.0), (0.0,0.0), (1.0,0.0), 
             (-1.0,-1.0), (0.0,-1.0), (1.0,-1.0) 
         ]
-        # FALSE case
+        # false case
         parameters_false2 = { 
-            "AREA1" : 10 
+            "area1" : 10 
         } 
 
         data_points_false2 = [ 
@@ -144,7 +144,7 @@ class TestDecide(unittest.TestCase):
             )
         )
     
-    def test_cmv_10(self):
+    def test_lic_10(self):
         # Define test parameters (should probably be moved to JSON test file later)
 
         parameters = {}
@@ -176,7 +176,7 @@ class TestDecide(unittest.TestCase):
         with self.assertRaises(AssertionError):   # Tests that NUMPOINTS-3 is larger than sum of E_PTS and F_PTS
             evaluate_LIC_10(num_points_less, datapoints_0, parameters)   
 
-    def test_cmv_11(self):
+    def test_lic_11(self):
         # Define test parameters (should probably be moved to JSON test file later)
         parameters = {
             "gpts" : 4
@@ -191,12 +191,12 @@ class TestDecide(unittest.TestCase):
 
 
         # Test computational logic in evaluate_LIC_11 function
-        self.assertFalse(evaluate_LIC_11(num_points, datapoints_1, parameters), "test_cmv_11: x vector is only increasing")
-        self.assertTrue(evaluate_LIC_11( num_points, datapoints_2, parameters), "test_cmv_11: x vector includes correct set of datapoints")
-        self.assertTrue(evaluate_LIC_11( num_points, datapoints_3, parameters), "test_cmv_11: x vector includes correct set of datapoints")
-        self.assertFalse(evaluate_LIC_11(num_points_less, datapoints_2, parameters), "test_cmv_11: NUMPOINTS less than 3")
+        self.assertFalse(evaluate_LIC_11(num_points, datapoints_1, parameters), "test_lic_11: x vector is only increasing")
+        self.assertTrue(evaluate_LIC_11( num_points, datapoints_2, parameters), "test_lic_11: x vector includes correct set of datapoints")
+        self.assertTrue(evaluate_LIC_11( num_points, datapoints_3, parameters), "test_lic_11: x vector includes correct set of datapoints")
+        self.assertFalse(evaluate_LIC_11(num_points_less, datapoints_2, parameters), "test_lic_11: NUMPOINTS less than 3")
 
-    def test_cmv_2(self):
+    def test_lic_2(self):
         """ 
         Tests the behavior of the set_cmv_2 function which should return true iff there exists
         three consecutive points s.t. the angle that they create is < PI - EPSILON or > PI - EPSILON
@@ -226,11 +226,11 @@ class TestDecide(unittest.TestCase):
         self.assertFalse(evaluate_LIC_2(len(datapoints_3), datapoints_3, parameters_3))
         self.assertTrue(evaluate_LIC_2(len(datapoints_4), datapoints_4, parameters_4))
 
-    def test_cmv_12(self):
+    def test_lic_12(self):
         num_points = 11    
-        parameters = { "KPTS" : 3 
-                     , "LENGTH1" : 10.0 
-                     , "LENGTH2" : 1.0 }
+        parameters = { "kpts" : 3 
+                     , "length1" : 10.0 
+                     , "length2" : 1.0 }
         data_points = [ (0.75,0.0), (1.0,0.0), (1.25,0.0), 
                         (1.5,0.0), (5.5,0.0), (3.0,0.0),  
                         (4.0,0.0), (5.0,0.0), (6.0,0.0), 
@@ -242,9 +242,9 @@ class TestDecide(unittest.TestCase):
         self.assertFalse(evaluate_LIC_12(num_points,data_points,parameters))
 
         num_points = 11    
-        parameters = { "KPTS" : 3 
-                     , "LENGTH1" : 10.0 
-                     , "LENGTH2" : 1.0 }
+        parameters = { "kpts" : 3 
+                     , "length1" : 10.0 
+                     , "length2" : 1.0 }
         data_points = [ (1.0,0.0), (2.0,0.0), (3.0,0.0), 
                         (4.0,0.0), (5.0,0.0), (6.0,0.0),  
                         (7.0,0.0), (8.0,0.0), (9.0,0.0), 
@@ -254,7 +254,7 @@ class TestDecide(unittest.TestCase):
         data_points[0] = np.array((4.5,0))
         self.assertTrue(evaluate_LIC_12(num_points,data_points,parameters))
 
-    def test_cmv_5(self):
+    def test_lic_5(self):
         # Define test parameters
         parameters = {}
 
@@ -271,7 +271,7 @@ class TestDecide(unittest.TestCase):
         self.assertTrue(evaluate_LIC_5(num_points, datapoints_3, parameters), "CMV_5: Points with negative x-values satisifes X[i] > X[i+1]")
         self.assertFalse(evaluate_LIC_5(num_points, datapoints_4, parameters), "CMV_5: Edge case -0, no satisfactory consecutive points")
 
-    def test_cmv_8(self):
+    def test_lic_8(self):
         """
         This function tests the set_cmv_8 function which is responsible for 
         LIC condition number 8. set_cmv_8 should return true iff there exist
@@ -298,12 +298,12 @@ class TestDecide(unittest.TestCase):
         self.assertTrue(evaluate_LIC_8(len(datapoints_2), datapoints_2, parameters_3))
         self.assertFalse(evaluate_LIC_8(len(datapoints_2), datapoints_2, parameters_4))
         
-    def test_cmv_14(self):
+    def test_lic_14(self):
         num_points = 8    
-        parameters = { "EPTS" : 2
-                     , "FPTS" : 2 
-                     , "AREA1" : 4.0 
-                     , "AREA2" : 1.1 }
+        parameters = { "epts" : 2
+                     , "fpts" : 2 
+                     , "area1" : 4.0 
+                     , "area2" : 1.1 }
         data_points = [ (0.0,0.0), (1.0,0.0), (2.0,0.0), 
                         (3.0,0.0), (3.0,1.0), (3.0,2.0),  
                         (3.0,3.0), (1.0,1.0)]
@@ -320,7 +320,7 @@ class TestDecide(unittest.TestCase):
         data_points = [np.array(e) for e in data_points]
         self.assertFalse(evaluate_LIC_14(num_points,data_points,parameters))
 
-    def test_cmv_1_equal_points(self):
+    def test_lic_1_equal_points(self):
         """
         Given a set of three points where two are equal and where the
         euclidean distance between the differing points is 2, 
@@ -332,7 +332,7 @@ class TestDecide(unittest.TestCase):
         num_points = len(datapoints)
         self.assertFalse(evaluate_LIC_1(num_points, datapoints, parameters))
 
-    def test_cmv_1_collinear(self):
+    def test_lic_1_collinear(self):
         """
         Given a set of three collinear points, the points should not 
         be able to be contained by a circle.
@@ -343,7 +343,7 @@ class TestDecide(unittest.TestCase):
         num_points = len(datapoints)
         self.assertFalse(evaluate_LIC_1(num_points, datapoints, parameters))
 
-    def test_cmv_1(self):
+    def test_lic_1(self):
         """
         The points (1, 0), (-1, 0), and (0, 1) should be contained a by a circle
         with radius 1. evaluate_LIC_1 should therefore be true with RADIUS set to 0.5
@@ -358,7 +358,7 @@ class TestDecide(unittest.TestCase):
         parameters["radius1"] = 1
         self.assertFalse(evaluate_LIC_1(num_points, datapoints, parameters))
 
-    def test_cmv_7(self):
+    def test_lic_7(self):
         """
         This function tests the set_cmv_7 function which is responsible for 
         LIC condition number 7. set_cmv_7 should return true iff there exist
@@ -383,7 +383,7 @@ class TestDecide(unittest.TestCase):
         # No points in datapoints_2 have a difference of 9 with 1 point in between
         self.assertFalse(evaluate_LIC_7(len(datapoints_2), datapoints_2, parameters_4))
 
-    def test_cmv_9_too_few_datapoints(self):
+    def test_lic_9_too_few_datapoints(self):
         # Define test parameters
         parameters = {
             'cpts' : 2,
@@ -397,7 +397,7 @@ class TestDecide(unittest.TestCase):
         # Test computational logic in evaluate_LIC_9 function
         self.assertFalse(evaluate_LIC_9(num_points, datapoints, parameters), "num_points is less than 5, not satisfactory")
 
-    def test_cmv_9_only_angles_of_PI_radians(self):
+    def test_lic_9_only_angles_of_PI_radians(self):
         # Define test parameters
         parameters = {
             'cpts' : 2,
@@ -411,7 +411,7 @@ class TestDecide(unittest.TestCase):
         # Test computational logic in evaluate_LIC_9 function
         self.assertFalse(evaluate_LIC_9(num_points, datapoints, parameters), "All points are along a line Y=0, angle is always pi which is in forbidden range")
     
-    def test_cmv_9_no_valid_angles(self):
+    def test_lic_9_no_valid_angles(self):
         # Define test parameters
         parameters = {
             'cpts' : 3,
@@ -425,7 +425,7 @@ class TestDecide(unittest.TestCase):
         # Test computational logic in evaluate_LIC_9 function
         self.assertFalse(evaluate_LIC_9(num_points, datapoints, parameters), "One angle close to the edge of invalid range, but still invalid. THe rest are clearly invalid")
 
-    def test_cmv_9_test_angles_close_to_unvalid_range(self):
+    def test_lic_9_test_angles_close_to_unvalid_range(self):
         # Define test parameters
         parameters = {
             'cpts' : 3,
@@ -441,7 +441,7 @@ class TestDecide(unittest.TestCase):
         self.assertTrue(evaluate_LIC_9(num_points, datapoints_0, parameters), "One set have an angle slightly less than PI/2, is outside forbidden range PI±PI/2")
         self.assertFalse(evaluate_LIC_9(num_points, datapoints_1, parameters), "All angles are PI exept on that is slightly greater than PI/2, still in forbidden range PI±PI/2")
 
-    def test_cmv_9_set_with_coinciding_points_followed_by_satisfactory_set(self):
+    def test_lic_9_set_with_coinciding_points_followed_by_satisfactory_set(self):
         
         # Define test parameters
         parameters = {
@@ -458,7 +458,7 @@ class TestDecide(unittest.TestCase):
         self.assertTrue(evaluate_LIC_9(num_points, datapoints_0, parameters), "The first set has coinciding points, the second last has a satisfactory set with angle≈0.4PI which is outside the invalid range PI±PI/2")
         self.assertTrue(evaluate_LIC_9(num_points, datapoints_1, parameters), "The first set has coinciding points, the second last has a satisfactory set with angle≈0.4PI which is outside the invalid range PI±PI/2")
 
-    def test_cmv_9_two_sets_with_coinciding_points_but_no_other_satisfactory_sets(self):
+    def test_lic_9_two_sets_with_coinciding_points_but_no_other_satisfactory_sets(self):
         
         # Define test parameters
         parameters = {
@@ -486,7 +486,7 @@ class TestDecide(unittest.TestCase):
         # Test the degenerate case (line is a point)
         self.assertAlmostEqual(distance_from_line((2, 3), (1, 1), (1, 1)), np.sqrt(5))
 
-    def test_cmv_6(self):
+    def test_lic_6(self):
         parameters = {
             "npts" : 3,
             "dist" : 1.0
@@ -500,9 +500,6 @@ class TestDecide(unittest.TestCase):
 
         self.assertFalse(evaluate_LIC_6(3, [(0, 0), (0.4, 0.5), (0, 0)], parameters))
 
-        # Test edge case with fewer than 3 points
-        self.assertFalse(evaluate_LIC_6(2, [(0, 0), (1, 1)], parameters))
-
         parameters = {
             "npts" : 3,
             "dist" : 10.0
@@ -511,14 +508,14 @@ class TestDecide(unittest.TestCase):
         # Test case where condition is not met
         self.assertFalse(evaluate_LIC_6(4, [(0, 0), (1, 1), (2, 2), (3, 3)], parameters))
 
-    def test_cmv_13(self):
+    def test_lic_13(self):
 
         num_points = 10
         parameters = {
-            "APTS" : 2,
-            "BPTS" : 3,
-            "RADIUS1" : 1,
-            "RADIUS2" : 2
+            "apts" : 2,
+            "bpts" : 3,
+            "radius1" : 1,
+            "radius2" : 2
         }
 
         datapoints_1 = [(0,0),(0,0),(0,0),(0,0),(0,0),(0,0),(0,0),(0,0),(0,0),(0,0)]
@@ -528,10 +525,10 @@ class TestDecide(unittest.TestCase):
 
 
         # Test computational logic in evaluate_LIC_13 function
-        self.assertFalse(evaluate_LIC_13(num_points, datapoints_1, parameters), "test_cmv_13: - ") # Tests when all points are the same
-        self.assertTrue( evaluate_LIC_13(num_points, datapoints_2, parameters), "test_cmv_13: - ") # Tests when many points are the origin but one combination is outside radius1
-        self.assertTrue( evaluate_LIC_13(num_points, datapoints_3, parameters), "test_cmv_13: - ") # Tests when two points are the same. Outside fo radius 1 but inside radius 2
-        self.assertFalse(evaluate_LIC_13(num_points, datapoints_4, parameters), "test_cmv_13: - ") # Tests colinear points that are outside both radius 1 and radius2 
+        self.assertFalse(evaluate_LIC_13(num_points, datapoints_1, parameters), "test_lic_13: - ") # Tests when all points are the same
+        self.assertTrue( evaluate_LIC_13(num_points, datapoints_2, parameters), "test_lic_13: - ") # Tests when many points are the origin but one combination is outside radius1
+        self.assertTrue( evaluate_LIC_13(num_points, datapoints_3, parameters), "test_lic_13: - ") # Tests when two points are the same. Outside fo radius 1 but inside radius 2
+        self.assertFalse(evaluate_LIC_13(num_points, datapoints_4, parameters), "test_lic_13: - ") # Tests colinear points that are outside both radius 1 and radius2 
     
 
     def test_smallest_containting_circle(self):


### PR DESCRIPTION
change names of all test_CMV_X to test_LIC_X

fix assertion error in test_LIC_6 by removing test case which tested something that was an assertion error

fix keyerrors in lic tests 3,13,14 (capitalized when should have not been)

closes #75 