### PR TITLE
fix: change method of finding the smallest circle containing 3 points

### DIFF
--- a/LIC_evaluation.py
+++ b/LIC_evaluation.py
@@ -27,69 +27,36 @@ def evaluate_LIC_0(num_points, datapoints, parameters):
     return False
 
 def evaluate_LIC_1(numpoints, datapoints, parameters):
-	"""
-	Set CMV_1 based on LIC 1
-	
-	Parameters
-	----------
-	num_points : (int)
-		Total number of data points
-	datapoints : List[Tuple[float, float]]
-		List of tuples 
-	parameters : (Dict)
-		Contains all the LIC and CMV parameters 
-		
-	Returns 
-	----------
-	Bool 
-		True if LIC 1 is fulfilled, else False    
     """
-	radius_cond = False
-	radius = parameters["radius1"]
+    Set CMV_1 based on LIC 1
 
-	for i in range(numpoints - 2):
-		p_1 = complex(datapoints[i][0], datapoints[i][1])
-		p_2 = complex(datapoints[i+1][0], datapoints[i+1][1])
-		p_3 = complex(datapoints[i+2][0], datapoints[i+2][1])
+    Parameters
+    ----------
+    num_points : (int)
+        Total number of data points
+    datapoints : List[Tuple[float, float]]
+        List of tuples 
+    parameters : (Dict)
+        Contains all the LIC and CMV parameters 
+        
+    Returns 
+    ----------
+    Bool 
+        True if LIC 1 is fulfilled, else False    
+    """
+    radius_cond = False
+    radius = parameters["radius1"]
 
-		# We can always encompass a single point
-		if p_1 == p_2 == p_3:
-			continue
+    for i in range(numpoints - 2):
+        p_1 = datapoints[i]
+        p_2 = datapoints[i+1]
+        p_3 = datapoints[i+2]
 
-		# If two points are equal, then check if the distance between
-		# the differing points is greater than the diameter. 
-		if p_1 == p_2:
-			if abs(p_3 - p_2) > 2*radius:
-				radius_cond = True
-			else:
-				continue
-		elif p_2 == p_3:
-			if abs(p_1 - p_3) > 2*radius:
-				radius_cond = True
-			else:
-				continue
-		elif p_3 == p_1:
-			if abs(p_2 - p_1) > 2*radius:
-				radius_cond = True
-			else:
-				continue
-		if radius_cond:
-			break
+        if smallest_containting_circle([p_1,p_2,p_3])[1] > radius:
+            radius_cond = True
+            break
 
-		# Code taken from https://math.stackexchange.com/questions/213658/get-the-equation-of-a-circle-when-given-3-points
-		w = (p_3 - p_1)/(p_2 - p_1)
-
-		# If the points are collinear, then they cannot create a circle
-		if abs(w.imag) <= 0.0001:
-			continue
-
-		c = (p_2 - p_1)*(w - abs(w)**2)/(2j*w.imag) + p_1  
-		circumradius = abs(p_1 - c)
-
-		if circumradius > radius:
-			radius_cond = True
-			break
-	return radius_cond
+    return radius_cond
 
 def evaluate_LIC_2(num_points, datapoints, parameters):
     epsilon = parameters["epsilon"]

--- a/test_decide.py
+++ b/test_decide.py
@@ -333,16 +333,6 @@ class TestDecide(unittest.TestCase):
         num_points = len(datapoints)
         self.assertFalse(evaluate_LIC_1(num_points, datapoints, parameters))
 
-    def test_lic_1_collinear(self):
-        """
-        Given a set of three collinear points, the points should not 
-        be able to be contained by a circle.
-        """
-        parameters = {}
-        parameters["radius1"] = 0.5
-        datapoints = [(1.0, 1.0), (2.0, 2.0), (3.0, 3.0)]
-        num_points = len(datapoints)
-        self.assertFalse(evaluate_LIC_1(num_points, datapoints, parameters))
 
     def test_lic_1(self):
         """

--- a/test_system.py
+++ b/test_system.py
@@ -38,7 +38,7 @@ parsed_input_1 = {
 
     "parameters" : {
         "length1"   : 500.0,
-        "radius1"   : 200.0,
+        "radius1"   : 100.0,
         "epsilon"   : 0.1,
         "area1"     : 20.0, 
         "qpts"      : 4,


### PR DESCRIPTION
Motivation:
Change one test case since we now have a better way of finding the smallest possible containing circle

Resolves #64
Authored-by: Sebastian Montén smonten@kth.se